### PR TITLE
Build remove operations from R to L for arrays

### DIFF
--- a/jsonpatch.go
+++ b/jsonpatch.go
@@ -237,7 +237,8 @@ func handleValues(av, bv interface{}, p string, patch []JsonPatchOperation) ([]J
 func compareArray(av, bv []interface{}, p string) []JsonPatchOperation {
 	retval := []JsonPatchOperation{}
 	//	var err error
-	for i, v := range av {
+	for i := len(av) - 1; i >= 0; i-- {
+		v := av[i]
 		found := false
 		for _, v2 := range bv {
 			if reflect.DeepEqual(v, v2) {

--- a/jsonpatch.go
+++ b/jsonpatch.go
@@ -269,7 +269,8 @@ func compareArray(av, bv []interface{}, p string) []JsonPatchOperation {
 			// if we're in the existing a space still, replace things
 			retval = append(retval, NewPatch("replace", makePath(p, i), v))
 			continue
-		} else {
+		} else if !replaceA {
+			// only search A if we're not replacing it
 			for _, v2 := range av {
 				if reflect.DeepEqual(v, v2) {
 					found = true

--- a/jsonpatch_array_test.go
+++ b/jsonpatch_array_test.go
@@ -1,0 +1,28 @@
+package jsonpatch
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var arrayA = `{"containers": ["a", "b"]}`
+var arrayB = `{"containers": ["c", "d", "e"]}`
+
+func TestPatchTwoCompletelyDifferentArrays(t *testing.T) {
+	patch, err := CreatePatch([]byte(arrayA), []byte(arrayB))
+
+	assert.NoError(t, err, "patch should not return an error")
+	s, _ := json.MarshalIndent(patch, "", "\t")
+	t.Log(string(s))
+
+	assert.Equal(t, len(patch), 5, "there should be 5 operations")
+	first := patch[0]
+	second := patch[1]
+
+	assert.Equal(t, "remove", first.Operation, "first operation should be a remove")
+	assert.Equal(t, "remove", second.Operation, "second operation should be a remove")
+	assert.Equal(t, "/containers/1", first.Path, "the first path should be index 1")
+	assert.Equal(t, "/containers/0", second.Path, "the second path should be index 0")
+}

--- a/jsonpatch_array_test.go
+++ b/jsonpatch_array_test.go
@@ -17,12 +17,15 @@ func TestPatchTwoCompletelyDifferentArrays(t *testing.T) {
 	s, _ := json.MarshalIndent(patch, "", "\t")
 	t.Log(string(s))
 
-	assert.Equal(t, len(patch), 5, "there should be 5 operations")
+	assert.Equal(t, len(patch), 3, "there should be 3 operations")
 	first := patch[0]
 	second := patch[1]
+	third := patch[2]
 
-	assert.Equal(t, "remove", first.Operation, "first operation should be a remove")
-	assert.Equal(t, "remove", second.Operation, "second operation should be a remove")
-	assert.Equal(t, "/containers/1", first.Path, "the first path should be index 1")
-	assert.Equal(t, "/containers/0", second.Path, "the second path should be index 0")
+	assert.Equal(t, "replace", first.Operation, "first operation should be a replace")
+	assert.Equal(t, "replace", second.Operation, "second operation should be a replace")
+	assert.Equal(t, "add", third.Operation, "third operation should be an add")
+	assert.Equal(t, "/containers/0", first.Path, "the first path should be index 0")
+	assert.Equal(t, "/containers/1", second.Path, "the second path should be index 1")
+	assert.Equal(t, "/containers/2", third.Path, "the third path should be index 2")
 }


### PR DESCRIPTION
Because remove operations in an array shift everything left, if we don't build remove operations from right to left we cause our indexes to be shifted which then make subsiquent operations reference the wrong index.

```
If removing an element from an array, any elements above the
   specified index are shifted one position to the left.
```


This also checks if we're replacing everything to replace in-place where we can instead of dropping everything and readding.

New patch generated

```
        [
        	{
        		"op": "replace",
        		"path": "/containers/0",
        		"value": "c"
        	},
        	{
        		"op": "replace",
        		"path": "/containers/1",
        		"value": "d"
        	},
        	{
        		"op": "add",
        		"path": "/containers/2",
        		"value": "e"
        	}
        ]
```